### PR TITLE
Fix crasher

### DIFF
--- a/app/code/community/Mailjet/Iframes/Model/Observer.php
+++ b/app/code/community/Mailjet/Iframes/Model/Observer.php
@@ -236,6 +236,8 @@ class Mailjet_Iframes_Model_Observer
         $credentialsOk = Mailjet_Iframes_Helper_Config::checkApiCredentials();
         if($credentialsOk) {
             $syncManager = new Mailjet_Iframes_Helper_SyncManager();
+        } else {
+            return false;
         }
         
         $customer = $observer->getCustomer();


### PR DESCRIPTION
If checkApiCredentials fail for missing properties, it can badly break checkout and other modules